### PR TITLE
configure.ac: correct name of device-mapper-devel for RHEL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ fi
 
 AC_CHECK_LIB([devmapper], [dm_task_create],
 	[DEVMAPPER_LIBS=-ldevmapper],
-	[AC_MSG_FAILURE([The libdevmapper development library is required by petitboot.  Try installing the package libdevmapper-dev or libdevmapper-devel.])]
+	[AC_MSG_FAILURE([The libdevmapper development library is required by petitboot.  Try installing the package libdevmapper-dev or device-mapper-devel.])]
 )
 
 AC_ARG_WITH([fdt],


### PR DESCRIPTION
The RHEL and Fedora package name for development device mapper library is device-mapper-devel

Signed-off-by: Daniel Black <daniel.black@au.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/petitboot/29)
<!-- Reviewable:end -->
