### PR TITLE
discover/grub2: Add support for initrd16 builtin

### DIFF
--- a/discover/grub2/builtins.c
+++ b/discover/grub2/builtins.c
@@ -356,6 +356,10 @@ static struct {
 		.fn = builtin_initrd,
 	},
 	{
+		.name = "initrd16",
+		.fn = builtin_initrd,
+	},
+	{
 		.name = "search",
 		.fn = builtin_search,
 	},


### PR DESCRIPTION
This commit adds support for the [initrd16 builtin](https://www.gnu.org/software/grub/manual/grub/html_node/initrd16.html#initrd16). The `linux16` builtin is already supported but for some reason `initrd16` isn't. This was discovered when using petitboot as a coreboot payload on an x86 machine.