### PR TITLE
travis: update dist from trusty to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 sudo: required
-dist: trusty
+dist: bionic
 
 before_install:
  - sudo apt-get -qq update


### PR DESCRIPTION
Some recent backports introduced to the 1.7.x branch are breaking the
travis-ci builds due to an obsolete libdevmapper-dev that doesn't include
the 'dm_task_geterrno()' function.

On the master branch, this is not observed due to the use of more modern
Ubuntu 18.04 (bionic) in the docker-based builds (that are not part of
the 1.7.x branch).

Instead of backporting the docker infrastructure to 1.7.x, simply bump
the 'dist' tag on this branch's .travis.yml file to use 'bionic' which
should solve the CI issues.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>