### PR TITLE
po/zh_CN.po: Fix "golden side" translation for chinese

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -558,7 +558,7 @@ msgid "BMC current side:"
 msgstr "BMC 当前侧："
 
 msgid "BMC golden side:"
-msgstr "BMC 金色一侧："
+msgstr "BMC 备用侧："
 
 msgid "Storage devices"
 msgstr "存储设备"


### PR DESCRIPTION
"金色" only represents one color in Chinese, and the "备用侧" is easier for customers to understand.