### PR TITLE
discover/network: Fix up nulling of dhcp client id args

### DIFF
--- a/discover/network.c
+++ b/discover/network.c
@@ -350,7 +350,7 @@ static void configure_interface_dhcp(struct network *network,
 		"-O", "reboottime",
 		"-p", pidfile,
 		"-i", interface->name,
-		"-x", idv4, /* [11,12] - dhcp client identifier */
+		"-x", idv4, /* [13,14] - dhcp client identifier */
 		NULL,
 	};
 
@@ -381,7 +381,7 @@ static void configure_interface_dhcp(struct network *network,
 		snprintf(idv4, sizeof(idv4), "0x5d:%04x",
 				platform->dhcp_arch_id);
 	} else {
-		argv_ipv4[11] = argv_ipv6[15] =  NULL;
+		argv_ipv4[13] = argv_ipv6[15] =  NULL;
 	}
 
 	p_v4 = process_create(interface);


### PR DESCRIPTION
Commit 6fa0edfb029726968cbacad9d4e193a345956ff3 added additional options
to the ipv4 udhcpc command but did not increment the offset for the dhcp
client identifier clearing to account for the new arguments.

Signed-off-by: Nathan Rossi <nathan.rossi@digi.com>