### PR TITLE
lib/security: Update full when generating signature url

### DIFF
--- a/lib/security/common.c
+++ b/lib/security/common.c
@@ -49,6 +49,8 @@ struct pb_url * get_signature_url(void *ctx, struct pb_url *base_file)
 	talloc_free(signature_file->path);
 	signature_file->path = talloc_asprintf(signature_file,
 		"%s.sig", base_file->path);
+	talloc_free(signature_file->full);
+	signature_file->full = pb_url_to_string(signature_file);
 
 	return signature_file;
 }


### PR DESCRIPTION
Update the full value of the pb_url when generating the signature url in
get_signature_url. This ensures that the full url matches the updated
path/file which includes the '.sig' extension.

Signed-off-by: Nathan Rossi <nathan.rossi@digi.com>