### PR TITLE
Prevent the UI from locking up while the countdown runs

### DIFF
--- a/discover/device-handler.c
+++ b/discover/device-handler.c
@@ -775,6 +775,7 @@ static void countdown_status(struct device_handler *handler,
 			_("Booting in %d sec: [%s] %s"), sec,
 			opt->device->device->id, opt->option->name);
 	status.backlog = false;
+	status.boot_active = false;
 
 	device_handler_status(handler, &status);
 


### PR DESCRIPTION
struct status has 4 parameters. Provide values for all of them
so that random values are not used instead.

Visible on an ARMv7 device as a "hang" (ignoring input) when the
countdown starts, after things have been probed.

Signed-off-by: Lincoln Ramsay <lincoln.ramsay@opengear.com>