### PR TITLE
Fix the petitboot MAC display

### DIFF
--- a/discover/network.c
+++ b/discover/network.c
@@ -677,6 +677,14 @@ static int network_handle_nlmsg(struct network *network, struct nlmsghdr *nlmsg)
 
 		list_add(&network->interfaces, &interface->list);
 		create_interface_dev(network, interface);
+	} else {
+		/* The interface can be marked as ready before the MAC address is set. */
+		if (memcmp(interface->hwaddr, ifaddr,
+			   sizeof(interface->hwaddr)) != 0) {
+			pb_log("%s: %s has changed MAC address\n",
+			       __func__, interface->name);
+			memcpy(interface->hwaddr, ifaddr, sizeof(interface->hwaddr));
+		}
 	}
 
 	/* A repeated RTM_NEWLINK can represent an interface name change */


### PR DESCRIPTION
Handle the MAC address changing via netlink so that the display
is correct. Also affects the tftp request.

Signed-off-by: Lincoln Ramsay <lincoln.ramsay@opengear.com>