### PR TITLE
utils: split yaboot sample config file from kboot one

### DIFF
--- a/utils/kboot.conf.sample
+++ b/utils/kboot.conf.sample
@@ -8,13 +8,3 @@
 # tftp='tftp://192.168.0.5/fire/boot/vmlinux.strip root=/dev/nfs rw ip=dhcp video=1080p'
 # nfs='nfs://192.168.0.5/fire/boot/vmlinux.strip root=/dev/nfs rw ip=dhcp video=1080p fbcon=rotate:3'
 # http_nfs='http://192.168.0.5/ice/boot/vmlinux.strip nfs://192.168.0.5/ice/boot/initrd root=/dev/nfs'
-
-# yaboot style samples:
-
-# image=/boot/vmlinux
-# 	label=yaboot-hdd
-# 	initrd=/boot/initrd.gz
-# 	append="root=/dev/sda1"
-# image=tftp://192.168.0.5/fire/boot/vmlinux.strip
-# 	label=yaboot-tftp
-# 	append="root=/dev/nfs rw ip=dhcp video=1080p"

--- a/utils/yaboot.conf.sample
+++ b/utils/yaboot.conf.sample
@@ -1,0 +1,13 @@
+# Sample yaboot.conf for petitboot
+# Copy to /etc/yaboot.conf and modify to match your system
+#
+
+# yaboot style samples:
+
+# image=/boot/vmlinux
+# 	label=yaboot-hdd
+# 	initrd=/boot/initrd.gz
+# 	append="root=/dev/sda1"
+# image=tftp://192.168.0.5/fire/boot/vmlinux.strip
+# 	label=yaboot-tftp
+# 	append="root=/dev/nfs rw ip=dhcp video=1080p"


### PR DESCRIPTION
I tried the yaboot sample config and (mis-)placed it in /etc/kboot.conf and it did not work. After renaming it to /etc/yaboot.conf it was OK.

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>