### PR TITLE
udev: check idpath for nullptr before calling strcmp

### DIFF
--- a/discover/udev.c
+++ b/discover/udev.c
@@ -181,7 +181,7 @@ static int udev_handle_block_add(struct pb_udev *udev, struct udev_device *dev,
 	/* We may see multipath devices; they'll have the same uuid as an
 	 * existing device, so only parse the first. */
 	uuid = udev_device_get_property_value(dev, "ID_FS_UUID");
-	idpath = udev_device_get_property_value(dev, "ID_PATH");
+	idpath = udev_device_get_property_value(dev, "ID_PATH") ?: "";
 	if (uuid) {
 		ddev = device_lookup_by_uuid(udev->handler, uuid);
 		if (ddev) {


### PR DESCRIPTION
While trying to package petitboot for postmarketos, I experienced segafults in [udev.c:191](https://github.com/open-power/petitboot/blob/master/discover/udev.c#L191). Seems that udev can return null for the ID_PATH property in some cases. This should be handled properly instead of calling strcmp on a null pointer.