### PR TITLE
discover/grub2: Ignore bare values in blscfg files

### DIFF
--- a/discover/grub2/blscfg.c
+++ b/discover/grub2/blscfg.c
@@ -124,6 +124,10 @@ static void bls_process_pair(struct conf_context *conf, const char *name,
 	struct discover_boot_option *opt = state->opt;
 	struct boot_option *option = opt->option;
 
+	/* ignore bare values */
+	if (!name)
+		return;
+
 	if (streq(name, "title")) {
 		state->title = expand_field(state, value);
 		return;

--- a/test/parser/Makefile.am
+++ b/test/parser/Makefile.am
@@ -56,6 +56,7 @@ parser_TESTS = \
 	test/parser/test-grub2-blscfg-default-filename \
 	test/parser/test-grub2-blscfg-default-index \
 	test/parser/test-grub2-blscfg-default-title \
+	test/parser/test-grub2-blscfg-fcos38 \
 	test/parser/test-grub2-blscfg-multiple-bls \
 	test/parser/test-grub2-blscfg-opts-config \
 	test/parser/test-grub2-blscfg-opts-grubenv \

--- a/test/parser/data/grub2-blscfg-fcos38.conf
+++ b/test/parser/data/grub2-blscfg-fcos38.conf
@@ -1,0 +1,8 @@
+title Fedora CoreOS 38.20230625.3.0 (ostree:1)
+version 1
+options mitigations=auto,nosmt ignition.platform.id=metal $ignition_firstboot ostree=/ostree/boot.0/fedora-coreos/00f1847831b603756e2804045135de37a3740b16b7777f8633b779e043222e29/0 root=UUID=198343c8-def9-4ac4-88ee-c6821e7e71ba rw rootflags=prjquota boot=UUID=4310acc5-6457-44fd-89e5-6a976d84ae0e
+linux /ostree/fedora-coreos-00f1847831b603756e2804045135de37a3740b16b7777f8633b779e043222e29/vmlinuz-6.3.8-200.fc38.ppc64le
+initrd /ostree/fedora-coreos-00f1847831b603756e2804045135de37a3740b16b7777f8633b779e043222e29/initramfs-6.3.8-200.fc38.ppc64le.img
+abootcfg /ostree/deploy/fedora-coreos/deploy/d21a842ae4aa2a8661a3e61b12dd32149dfe2b4b53abb1e1253c172167eb4be3.0/usr/lib/ostree-boot/aboot.cfg
+grub_users ""
+aboot /ostree/deploy/fedora-coreos/deploy/d21a842ae4aa2a8661a3e61b12dd32149dfe2b4b53abb1e1253c172167eb4be3.0/usr/lib/ostree-boot/aboot.img

--- a/test/parser/test-grub2-blscfg-fcos38.c
+++ b/test/parser/test-grub2-blscfg-fcos38.c
@@ -1,0 +1,23 @@
+#include "parser-test.h"
+
+#if 0 /* PARSER_EMBEDDED_CONFIG */
+blscfg
+#endif
+
+void run_test(struct parser_test *test)
+{
+	struct discover_context *ctx;
+
+	ctx = test->ctx;
+
+	test_add_dir(test, ctx->device, "/loader/entries");
+
+	test_read_conf_file(test, "grub2-blscfg-fcos38.conf",
+			    "/loader/entries/ostree-1-fedora-coreos.conf");
+
+	test_read_conf_embedded(test, "/grub2/grub.cfg");
+
+	test_run_parser(test, "grub2");
+
+	check_boot_option_count(ctx, 1);
+}


### PR DESCRIPTION
Fix for a bug found recently, when a boot source was upgraded from Fedora CoreOS 38 to 39. The new bootloader config (inadvertently) contained a bare value:
```
grub_users ""
```