### PR TITLE
Include <libgen.h> when using basename()

### DIFF
--- a/discover/grub2/blscfg.c
+++ b/discover/grub2/blscfg.c
@@ -3,9 +3,10 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <dirent.h>
+#include <libgen.h>
 #include <stdlib.h>
 #include <string.h>
-#include <dirent.h>
 
 #include <log/log.h>
 #include <file/file.h>

--- a/ui/ncurses/nc-plugin.c
+++ b/ui/ncurses/nc-plugin.c
@@ -20,6 +20,7 @@
 #endif
 
 #include <errno.h>
+#include <libgen.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
basename() is part of libgen.h in POSIX, so import it before using.

This fixes the build on musl libc with gcc 15+.