### PR TITLE
ui/ncurses: properly update menu labels in pmenu_item_update()

### DIFF
--- a/ui/ncurses/nc-cui.c
+++ b/ui/ncurses/nc-cui.c
@@ -1062,6 +1062,7 @@ static int cui_boot_option_add(struct device *dev, struct boot_option *opt,
 			char *label = talloc_asprintf(item, _("Plugins (%u)"),
 					cui->n_plugins);
 			pmenu_item_update(item, label);
+			cui->main->items[j] = item->nci;
 			talloc_free(label);
 			break;
 		}
@@ -1083,6 +1084,7 @@ static int cui_boot_option_add(struct device *dev, struct boot_option *opt,
 					char *label =  talloc_asprintf(menu, "%s%s",
 							tab, tmp->name ? : "Unknown Name");
 					pmenu_item_update(item, label);
+					cui->main->items[j] = item->nci;
 					talloc_free(label);
 					break;
 				}
@@ -1435,8 +1437,10 @@ fallback:
 	/* This disconnects items array from menu. */
 	result = set_menu_items(cui->plugin_menu->ncm, NULL);
 
-	if (result == E_OK)
+	if (result == E_OK) {
 		pmenu_item_update(item, cod->name);
+		cui->plugin_menu->items[i] = item->nci;
+	}
 
 	/* Re-attach the items array. */
 	result = set_menu_items(cui->plugin_menu->ncm, cui->plugin_menu->items);
@@ -1497,6 +1501,7 @@ static int cui_plugins_remove(void *arg)
 			continue;
 		cui->n_plugins = 0;
 		pmenu_item_update(item, _("Plugins (0)"));
+		cui->main->items[i] = item->nci;
 		break;
 	}
 

--- a/ui/ncurses/nc-menu.c
+++ b/ui/ncurses/nc-menu.c
@@ -147,10 +147,13 @@ int pmenu_item_update(struct pmenu_item *item, const char *name)
 		talloc_free((char *)label);
 		return -1;
 	}
+
 	talloc_free((char *)item->label);
 	free_item(item->nci);
 	item->label = label;
 	item->nci = i;
+
+	set_item_userptr(item->nci, item);
 
 	return 0;
 }
@@ -630,4 +633,3 @@ int pmenu_setup(struct pmenu *menu)
 
 	return 0;
 }
-


### PR DESCRIPTION
`pmenu_item_update()` takes care of updating the menu label. It does this by allocating a new (ncurses) menu item with the name provided. However, the `**items` array wasn't updated, referencing the already freed memory.

This is observed while saving the configuration (the UI will crash and leave to the shell). Discovered this when I was implementing and testing my file backed configuration storage.

This patch sets the userptr of the newly created menu item, and updates the element in the `(struct pmenu *)->items[]` array accordingly.